### PR TITLE
support group-limited auto-expandable command widths

### DIFF
--- a/lib/yeesh/builtin/help.ex
+++ b/lib/yeesh/builtin/help.ex
@@ -105,8 +105,15 @@ defmodule Yeesh.Builtin.Help do
   defp group_sort_key(name), do: {2, name}
 
   defp format_commands(commands) do
+    width =
+      commands
+      |> Enum.map(fn {cmd_name, _} -> String.length(cmd_name) end)
+      |> Enum.max()
+      |> max(14)
+      |> Kernel.+(2)
+
     Enum.map_join(commands, "\r\n", fn {cmd_name, module} ->
-      padded = String.pad_trailing(cmd_name, 16)
+      padded = String.pad_trailing(cmd_name, width)
       "  " <> Output.green(padded) <> module.description()
     end)
   end

--- a/test/yeesh/builtin/help_test.exs
+++ b/test/yeesh/builtin/help_test.exs
@@ -116,4 +116,22 @@ defmodule Yeesh.Builtin.HelpTest do
       assert output =~ "help"
     end
   end
+
+  describe "execute/2 formatting" do
+    test "long command names are not glued to their description" do
+      defmodule LongNameCmd do
+        @behaviour Yeesh.Command
+        def name, do: "very-long-command"
+        def description, do: "Does something"
+        def usage, do: "very-long-command"
+        def group, do: "Test"
+        def execute(_args, session), do: {:ok, "", session}
+      end
+
+      Registry.register(LongNameCmd)
+      {:ok, output, _session} = Help.execute([], %Session{})
+
+      refute output =~ "very-long-commandDoes something"
+    end
+  end
 end


### PR DESCRIPTION
Supports commands longer than 14 characters in total - specially useful for multi-word commands.