### PR TITLE
focus the terminal itself when the element is focused

### DIFF
--- a/lib/yeesh/live/terminal_component/yeesh-terminal-element.html.heex
+++ b/lib/yeesh/live/terminal_component/yeesh-terminal-element.html.heex
@@ -109,6 +109,14 @@
       this.#deinitTerm();
     }
 
+    focus( options) {
+      if( this.term) {
+        this.term.focus();
+        return;
+      }
+      this.updateComplete.then(() => this.term?.focus());
+    }
+
     // Initializers, deinitialziers
 
     #initTheme() {

--- a/lib/yeesh/live/terminal_component/yeesh-terminal-element.html.heex
+++ b/lib/yeesh/live/terminal_component/yeesh-terminal-element.html.heex
@@ -109,8 +109,8 @@
       this.#deinitTerm();
     }
 
-    focus( options) {
-      if( this.term) {
+    focus(options) {
+      if(this.term) {
         this.term.focus();
         return;
       }


### PR DESCRIPTION
Necessary to get the terminal ready for typing (with its caret blinking) as soon as the component itself gains focus.